### PR TITLE
Make error messages more helpful

### DIFF
--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -96,9 +96,9 @@ const apolloServer = new ApolloServer({
 	validationRules: [ComplexityLimitRule],
 	formatError: err => {
 		const safeError =
-			err.originalError instanceof ApolloError ||
+			err instanceof ApolloError ||
 			err instanceof ValidationError ||
-			(err.originalError && err.originalError.message === "Not allowed by CORS");
+			(err && err.message === "Not allowed by CORS");
 
 		const internalError = err && err.extensions && err.extensions.code && err.extensions.code === "INTERNAL_SERVER_ERROR";
 


### PR DESCRIPTION
Apparently our error handler overreacted to most errors by treating all of them as "unknown" or "critical" due to breaking API changes at Apollo

In other news it's very concerning how user input errors only read as a 400 on the client side with no passthrough of error message/form location, just a system traceback - might be another breaking change?